### PR TITLE
Update for DST Rework

### DIFF
--- a/Send-Signal.ps1
+++ b/Send-Signal.ps1
@@ -81,8 +81,9 @@ function Send-Events {
             
             $tz = [TimeZoneInfo]::Local
             $supportDst = $tz.SupportsDaylightSavingTime
-            $dst = $tz.IsDaylightSavingTime(0)
-            if($supportDst -match "True" -and $dst -match "False") {
+            $date = Get-Date
+            $dst = $date.IsDaylightSavingTime()
+            if($supportDst -match "True" -and $dst -match "True") {
                 $tzinfo = (($tz.BaseUtcOffset.Hours) + 1).ToString("00") + [Math]::abs($tz.BaseUtcOffset.Minutes).ToString("00")
             } else  {
                 $tzinfo = $tz.BaseUtcOffset.Hours.ToString("00") + [Math]::abs($tz.BaseUtcOffset.Minutes).ToString("00")


### PR DESCRIPTION
Existing logic was wrong. It did fix the specific issue given we are IN DST right now, but didn't fix the whole problem (year round) because $dst = $tz.IsDaylightSavingTime(0) never returns the correct boolean.
IsDaylightSavingTime does accurately report a boolean from the Get-Date command. So this new logic is if supportDst=True AND IsDaylightSavingTime=true then drop an hour.